### PR TITLE
Docs: Drop Trello references, point at GitHub instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Useful Links
 * Blog: https://travellermap.blogspot.com
 * GitHub repo: https://github.com/inexorabletash/travellermap
 * Issue tracker: https://github.com/inexorabletash/travellermap/issues
-* Wish List: https://trello.com/b/y61wmEKJ/travellermap-com-wish-list
 
 
 Dependencies

--- a/doc/about.html
+++ b/doc/about.html
@@ -106,8 +106,8 @@
       <a target=_blank rel=noopener href="https://github.com/inexorabletash/travellermap/commits/main">commits on GitHub</a>, or following the <a target=_blank rel=noopener href="https://dice.camp/@travellermap">@TravellerMap Mastodon feed</a>.
     </p>
     <p>
-      A "Wish List", including known issues, can be found on the
-      <a target=_blank rel=noopener href="https://trello.com/board/travellermap-com-wish-list/4f39e3c4db00e4a256036985">Trello TravellerMap.com Wish List</a>.
+      Bug reports and feature requests can be made using the
+      <a target=_blank rel=noopener href="https://github.com/inexorabletash/travellermap/issues">Issue Tracker</a>.
     </p>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -426,7 +426,7 @@
       <p>
         <a target=_blank rel=noopener href="https://travellermap.blogspot.com/">News &amp; Feedback</a>
         &bull;
-        <a target=_blank rel=noopener href="https://trello.com/b/y61wmEKJ/travellermap-com-wish-list">Wish List</a>
+        <a target=_blank rel=noopener href="https://github.com/inexorabletash/travellermap/issues">Bug Reports</a>
       </p>
 
     </section>


### PR DESCRIPTION
I haven't looked at Trello in years so stop pointing people at it.